### PR TITLE
To avoid (@Bindable must be on a member in an Observable class. MainV…

### DIFF
--- a/app/src/main/java/com/resocoder/databinding/MainViewModel.kt
+++ b/app/src/main/java/com/resocoder/databinding/MainViewModel.kt
@@ -1,12 +1,23 @@
 package com.resocoder.databinding
 
 import androidx.databinding.Bindable
+import androidx.databinding.Observable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 
-class MainViewModel : ViewModel() {
+class MainViewModel : ViewModel(), Observable {
+    
+    private val callbacks: PropertyChangeRegistry by lazy { PropertyChangeRegistry() }
+
+    override fun removeOnPropertyChangedCallback(callback: Observable.OnPropertyChangedCallback?) {
+        callbacks.add(callback)
+    }
+
+    override fun addOnPropertyChangedCallback(callback: Observable.OnPropertyChangedCallback?) {
+        callbacks.remove(callback)
+    }
 
     val currentRandomFruitName: LiveData<String>
         get() = FakeRepository.currentRandomFruitName


### PR DESCRIPTION
To avoid (@Bindable must be on a member in an Observable class. MainViewModel is not Observable) error.